### PR TITLE
Use same fb for capturing an image and detecting objects

### DIFF
--- a/firmware/include/object_detection.h
+++ b/firmware/include/object_detection.h
@@ -10,6 +10,6 @@
  *   x:    'PosX',
  *   y:    'PosY' } 
  */
-std::vector<std::unordered_map<std::string, std::string>> CaptureImage();
-void ObjectDetectionSetup();
+std::vector<std::unordered_map<std::string, std::string>> GetDetectedObjects();
+void DetectObjects(uint8_t *fb_buf, size_t fb_len);
 #endif

--- a/firmware/src/wifi_station.cpp
+++ b/firmware/src/wifi_station.cpp
@@ -80,30 +80,30 @@ void loadPoints(String str) {
 
 
 void handleObjects() {
-  std::vector<std::unordered_map<std::string, std::string>> data = CaptureImage();
-  // Calculate the capacity of the JSON document
-  size_t capacity = JSON_ARRAY_SIZE(data.size()) + data.size() * JSON_OBJECT_SIZE(data[0].size());
+    std::vector<std::unordered_map<std::string, std::string>> data = GetDetectedObjects();
+    // Calculate the capacity of the JSON document
+    size_t capacity = JSON_ARRAY_SIZE(data.size()) + data.size() * JSON_OBJECT_SIZE(data[0].size());
 
-  // Create a DynamicJsonDocument using the calculated capacity
-  DynamicJsonDocument doc(capacity);
+    // Create a DynamicJsonDocument using the calculated capacity
+    DynamicJsonDocument doc(capacity);
 
-  // Create a JsonArray to hold the array of objects
-  JsonArray array = doc.to<JsonArray>();
+    // Create a JsonArray to hold the array of objects
+    JsonArray array = doc.to<JsonArray>();
 
-  // Iterate over the vector of unordered_maps and add each element to the JsonArray
-  for (const auto& element : data) {
-    JsonObject obj = array.createNestedObject();
-    for (const auto& kv : element) {
-      obj[kv.first.c_str()] = kv.second.c_str();
+    // Iterate over the vector of unordered_maps and add each element to the JsonArray
+    for (const auto& element : data) {
+        JsonObject obj = array.createNestedObject();
+        for (const auto& kv : element) {
+            obj[kv.first.c_str()] = kv.second.c_str();
+        }
     }
-  }
 
-  // Serialize the JSON document to a string
-  String jsonString;
-  serializeJson(doc, jsonString);
-  Serial.println(jsonString);
-  // Send as response
-  server.send(200, "text/json", jsonString);
+    // Serialize the JSON document to a string
+    String jsonString;
+    serializeJson(doc, jsonString);
+    Serial.println(jsonString);
+    // Send as response
+    server.send(200, "text/json", jsonString);
 }
 
 // Espera recibir 2 parámetros
@@ -138,6 +138,8 @@ void handleCamera() {
         Serial.println("Error al capturar imagen");
         server.send(500);
     } else {
+        DetectObjects(fb->buf, fb->len);
+
         server.sendHeader("Content-Disposition", "inline; filename=capture.jpg");
         server.send_P(200, "image/jpeg", (const char *)fb->buf, fb->len);
     }


### PR DESCRIPTION
## Qué se hizo 
- Evitar que se tomen 2 fotos separadas al clickear 'Refrescar' (una para detectar y otra para reemplazar el fondo del canvas).